### PR TITLE
#16198 - Only pass nh link-local if it exists

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2487,6 +2487,7 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 		     && IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_local))
 		    || (!reflect && !transparent
 			&& IN6_IS_ADDR_LINKLOCAL(&peer->nexthop.v6_local)
+			&& IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_local)
 			&& peer->shared_network
 			&& (from == bgp->peer_self
 			    || peer->sort == BGP_PEER_EBGP))) {


### PR DESCRIPTION
If the intent of this code is to either maintain the next-hop as-is
when policy is applied (`PEER_FLAG_NEXTHOP_LOCAL_UNCHANGED`)
*** OR ***
Pass the next-hop including link-local when we share the network,
then we should probably check also if the nh link-local actually
exists in the record.
*** ELSE ***
Strip the nh link-local 